### PR TITLE
[BE] feat: 공지사항 상세 페이지 조회 구현

### DIFF
--- a/backend/JiShop/src/main/java/com/jishop/common/exception/ErrorType.java
+++ b/backend/JiShop/src/main/java/com/jishop/common/exception/ErrorType.java
@@ -8,7 +8,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorType {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    // USER
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // NOTICE
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/JiShop/src/main/java/com/jishop/controller/NoticeController.java
+++ b/backend/JiShop/src/main/java/com/jishop/controller/NoticeController.java
@@ -1,5 +1,6 @@
 package com.jishop.controller;
 
+import com.jishop.dto.NoticeDetailResponse;
 import com.jishop.dto.NoticeResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
@@ -9,4 +10,5 @@ import org.springframework.data.web.PagedModel;
 public interface NoticeController {
 
     public PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
+    public NoticeDetailResponse getNotice(Long id);
 }

--- a/backend/JiShop/src/main/java/com/jishop/controller/NoticeController.java
+++ b/backend/JiShop/src/main/java/com/jishop/controller/NoticeController.java
@@ -9,6 +9,6 @@ import org.springframework.data.web.PagedModel;
 @Tag(name = "공지사항 API")
 public interface NoticeController {
 
-    public PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
-    public NoticeDetailResponse getNotice(Long id);
+    PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
+    NoticeDetailResponse getNotice(Long id);
 }

--- a/backend/JiShop/src/main/java/com/jishop/controller/impl/NoticeControllerImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/controller/impl/NoticeControllerImpl.java
@@ -1,6 +1,7 @@
 package com.jishop.controller.impl;
 
 import com.jishop.controller.NoticeController;
+import com.jishop.dto.NoticeDetailResponse;
 import com.jishop.dto.NoticeResponse;
 import com.jishop.service.NoticeService;
 import lombok.RequiredArgsConstructor;
@@ -8,9 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +23,11 @@ public class NoticeControllerImpl implements NoticeController {
     public PagedModel<NoticeResponse> getAllNotices(
             @PageableDefault(page = 0, size = 15, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return noticeService.getAllNotices(pageable);
+    }
+
+    @Override
+    @GetMapping("/{id}")
+    public NoticeDetailResponse getNotice(@PathVariable Long id) {
+        return noticeService.getNotice(id);
     }
 }

--- a/backend/JiShop/src/main/java/com/jishop/dto/NoticeDetailResponse.java
+++ b/backend/JiShop/src/main/java/com/jishop/dto/NoticeDetailResponse.java
@@ -5,7 +5,6 @@ import com.jishop.domain.Notice;
 import java.time.LocalDateTime;
 
 public record NoticeDetailResponse(
-
         String title,
         String content,
         String priority,

--- a/backend/JiShop/src/main/java/com/jishop/dto/NoticeDetailResponse.java
+++ b/backend/JiShop/src/main/java/com/jishop/dto/NoticeDetailResponse.java
@@ -1,0 +1,22 @@
+package com.jishop.dto;
+
+import com.jishop.domain.Notice;
+
+import java.time.LocalDateTime;
+
+public record NoticeDetailResponse(
+
+        String title,
+        String content,
+        String priority,
+        LocalDateTime createdDate
+) {
+    public static NoticeDetailResponse from(Notice notice) {
+        return new NoticeDetailResponse(
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getPriority().name(),
+                notice.getCreatedAt()
+        );
+    }
+}

--- a/backend/JiShop/src/main/java/com/jishop/dto/NoticeResponse.java
+++ b/backend/JiShop/src/main/java/com/jishop/dto/NoticeResponse.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 public record NoticeResponse(
 
         String title,
-        String content,
         String priority,
         LocalDateTime createdDate
 
@@ -15,7 +14,6 @@ public record NoticeResponse(
     public static NoticeResponse from(Notice notice) {
         return new NoticeResponse(
                 notice.getTitle(),
-                notice.getContent(),
                 notice.getPriority().name(),
                 notice.getCreatedAt()
         );

--- a/backend/JiShop/src/main/java/com/jishop/dto/NoticeResponse.java
+++ b/backend/JiShop/src/main/java/com/jishop/dto/NoticeResponse.java
@@ -5,7 +5,6 @@ import com.jishop.domain.Notice;
 import java.time.LocalDateTime;
 
 public record NoticeResponse(
-
         String title,
         String priority,
         LocalDateTime createdDate

--- a/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
@@ -1,7 +1,13 @@
 package com.jishop.repository;
 
+import com.jishop.common.exception.DomainException;
+import com.jishop.common.exception.ErrorType;
 import com.jishop.domain.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    default Notice findOne(Long id){
+        return findById(id).orElseThrow(()->new DomainException(ErrorType.NOTICE_NOT_FOUND));
+    }
 }

--- a/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
@@ -4,7 +4,9 @@ import com.jishop.common.exception.DomainException;
 import com.jishop.common.exception.ErrorType;
 import com.jishop.domain.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     default Notice findOne(Long id){

--- a/backend/JiShop/src/main/java/com/jishop/service/NoticeService.java
+++ b/backend/JiShop/src/main/java/com/jishop/service/NoticeService.java
@@ -1,5 +1,6 @@
 package com.jishop.service;
 
+import com.jishop.dto.NoticeDetailResponse;
 import com.jishop.dto.NoticeResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
@@ -8,4 +9,6 @@ public interface NoticeService {
 
     // 공지사항 전체 목록 조회
     public PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
+    // 공지사항 상세 조회
+    public NoticeDetailResponse getNotice(Long id);
 }

--- a/backend/JiShop/src/main/java/com/jishop/service/NoticeService.java
+++ b/backend/JiShop/src/main/java/com/jishop/service/NoticeService.java
@@ -8,7 +8,7 @@ import org.springframework.data.web.PagedModel;
 public interface NoticeService {
 
     // 공지사항 전체 목록 조회
-    public PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
+    PagedModel<NoticeResponse> getAllNotices(Pageable pageable);
     // 공지사항 상세 조회
-    public NoticeDetailResponse getNotice(Long id);
+    NoticeDetailResponse getNotice(Long id);
 }

--- a/backend/JiShop/src/main/java/com/jishop/service/impl/NoticeServiceImpl.java
+++ b/backend/JiShop/src/main/java/com/jishop/service/impl/NoticeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jishop.service.impl;
 
+import com.jishop.dto.NoticeDetailResponse;
 import com.jishop.dto.NoticeResponse;
 import com.jishop.repository.NoticeRepository;
 import com.jishop.service.NoticeService;
@@ -17,8 +18,15 @@ public class NoticeServiceImpl implements NoticeService {
     private final NoticeRepository noticeRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public PagedModel<NoticeResponse> getAllNotices(Pageable pageable) {
         return new PagedModel<>(noticeRepository.findAll(pageable)
                 .map(NoticeResponse::from));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public NoticeDetailResponse getNotice(Long id) {
+        return NoticeDetailResponse.from(noticeRepository.findOne(id));
     }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #16 
---

### 🚀 어떤 기능을 구현했나요 ?
- 공지사항의 상세 페이지를 조회하는 기능 구현

### 🔥 어떤 문제를 마주했나요 ?
- Repository에서 `findById()` 로 데이터를 조회할 때, 
메서드 반환타입이 `Optional` 이기 때문에 `orElse...`로 처리해주는 코드를 
서비스 레이어에서 구현하는게 좋을지에 대한 고민

### ✨ 어떻게 해결했나요 ?
- Repository에서 `findOne()` 이라는 메서드를 작성하고,
`fineOne()` 메서드 내에서는 `findById()`와 `orElseThrow`로 `Notice` 도메인에 대한 예외를 발생시키도록 함

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- FE팀와 공통 응답 포맷으로, 데이터가 없는 경우 빈 리스트를 반환하기로 했는데
`orElseThrow()`로 예외를 발생시키는게 맞는지 고민됩니다 !!
이 부분에 대해서 의견 주세요! 

### 📚 참고 자료 및 회고 
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->
-
