### PR TITLE
[BE] feat: 공지사항 전체 목록 조회 시 중요도에 따른 정렬

### DIFF
--- a/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
+++ b/backend/JiShop/src/main/java/com/jishop/repository/NoticeRepository.java
@@ -3,7 +3,10 @@ package com.jishop.repository;
 import com.jishop.common.exception.DomainException;
 import com.jishop.common.exception.ErrorType;
 import com.jishop.domain.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +15,19 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     default Notice findOne(Long id){
         return findById(id).orElseThrow(()->new DomainException(ErrorType.NOTICE_NOT_FOUND));
     }
+
+    // 공지사항 전체 목록 시 중요도에 따라 정렬
+        // 중요도는 긴급(EMERGENCY) > 중요(IMPORTANT) > 일반(NORMAL)순서로 정렬
+        // 긴급은 작성 날짜와 관계없이 일반, 중요 보다 항상 상단에 고정
+        // 동일한 중요도 내에서는 최신 작성 순으로 정렬
+    @Query("SELECT n FROM Notice n " +
+            "ORDER BY " +
+            "CASE n.priority " +
+            "    WHEN 'EMERGENCY' THEN 3 " +
+            "    WHEN 'IMPORTANT' THEN 2 " +
+            "    WHEN 'NORMAL' THEN 1 " +
+            "    ELSE 0 " +
+            "END DESC, " +
+            "n.createdAt DESC")
+    Page<Notice> findAll(Pageable pageable);
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- resolves #에는 발행한 이슈 번호를 기입해주세요 -->

- resolves #25 

---

### 🚀 어떤 기능을 구현했나요 ?
- 공지사항 전체 목록 조회 시 중요도에 따른 정렬 기능
  - 중요도는 `긴급` > `중요` > `일반` 순서로 정렬
  - 동일한 중요도 내에서는 최신 작성 순으로 정렬 

### 🔥 어떤 문제를 마주했나요 ?
1. 정렬 요구사항을 레포지토리에서 정렬해야 할지,
JPA에서 기본으로 제공하는 `findAll()` 메서드를 이용해 
서비스 레이어에서 정렬 기능을 구현해야할지 고민

2. JPA 쿼리 메서드 사용과 `@Query` 사용 중 어떤 걸 사용해야 할 지 고민

### ✨ 어떻게 해결했나요 ?
1. 레포지토리 레이어에서 정렬하도록 기능 구현
2. `@Query` 를 사용해 정렬
-  레포지토리에서 JPA 쿼리 메서드를 사용하기 위해
`findAllByOrderByPriorityDescCreatedAtDesc()` 메서드를 사용하면
공지사항의 중요도(`긴급`>`중요`>`일반`)이 아닌 중요도를 나타내는 enum 인스턴스의
알파벳 순으로 정렬되는 문제가 있었습니다.

- 따라서 쿼리 메서드 대신 `@Query` 어노테이션을 사용해 SQL을 직접 입력했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 공지사항 목록 조회에서는 `QueryDSL`을 사용해 동적 쿼리를 작성할 필요가 없다고 생각해
`@Query`와 JPQL을 사용했는데 이 부분에 대해 리뷰 부탁드립니다~!


### 📚 Postman 테스트 결과
<!--참고 자료(ref) 링크 및 스크린샷, 구현 과정에 대한 회고-->

<img src ="https://github.com/user-attachments/assets/5129b9d2-b2d6-40b3-8556-9914be82f3be" width = 50%>

<img src = "https://github.com/user-attachments/assets/92d234ba-51de-4af6-be13-7b0bb80e8bd6" width = 50%>
